### PR TITLE
fix: Use ContextCompat to get colors and fix build

### DIFF
--- a/.github/workflows/android-manual-build.yml
+++ b/.github/workflows/android-manual-build.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Make Gradle executable
         run: chmod +x ./gradlew
 
+      - name: Create local.properties
+        run: echo "sdk.dir=${ANDROID_HOME}" > local.properties
+
       - name: Build (Debug APK)
         run: ./gradlew --no-daemon clean assembleDebug
 

--- a/app/src/main/java/com/synack/clipgrabber/MainActivity.java
+++ b/app/src/main/java/com/synack/clipgrabber/MainActivity.java
@@ -11,6 +11,7 @@ import android.provider.Settings;
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Environment;
+import androidx.core.content.ContextCompat;
 
 import java.io.*;
 
@@ -38,19 +39,19 @@ public class MainActivity extends Activity {
         LinearLayout layout = new LinearLayout(this);
         layout.setOrientation(LinearLayout.VERTICAL);
         layout.setPadding(50, 100, 50, 100);
-        layout.setBackgroundColor(getResources().getColor(R.color.syn_bg));
+        layout.setBackgroundColor(ContextCompat.getColor(this, R.color.syn_bg));
 
         Button toggleButton = new Button(this);
         toggleButton.setText("Turn ON");
         toggleButton.setBackground(getDrawable(R.drawable.bg_modern_button));
-        toggleButton.setTextColor(getResources().getColor(android.R.color.black));
+        toggleButton.setTextColor(ContextCompat.getColor(this, android.R.color.black));
         toggleButton.setElevation(8f);
 
 
         Button chooseDirButton = new Button(this);
         chooseDirButton.setText("Choose Save Directory");
         chooseDirButton.setBackground(getDrawable(R.drawable.bg_modern_button));
-        chooseDirButton.setTextColor(getResources().getColor(android.R.color.black));
+        chooseDirButton.setTextColor(ContextCompat.getColor(this, android.R.color.black));
         chooseDirButton.setElevation(8f);
 
 


### PR DESCRIPTION
This commit fixes a build failure by replacing the deprecated `getResources().getColor()` method with `ContextCompat.getColor()`. This change is necessary for the build to succeed in stricter environments like GitHub Actions.